### PR TITLE
feat: make extension type wrappers fallible

### DIFF
--- a/geopolars/geopolars-extension/src/factory.rs
+++ b/geopolars/geopolars-extension/src/factory.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use arrow_schema::extension::ExtensionType;
 use geoarrow_schema::GeoArrowType;
 use geopolars_arrow::to_arrow::polars_field_to_arrow;
 use polars::prelude::extension::{ExtensionTypeFactory, ExtensionTypeImpl};
@@ -38,27 +39,51 @@ impl ExtensionTypeFactory for GeoArrowExtensionTypeFactory {
         let arrow_field =
             arrow_schema::Field::new("", arrow_data_type, true).with_metadata(arrow_metadata);
 
-        // TODO: are we assured that the name matches the type here?
-        // What do we do if the storage type isn't compatible with the extension type?
-        let geoarrow_type = GeoArrowType::from_extension_field(&arrow_field)
-            .expect("Creation of GeoArrow extension type");
-
-        match geoarrow_type {
-            GeoArrowType::Point(t) => Box::new(PointType::new(t)),
-            GeoArrowType::LineString(t) => Box::new(LineStringType::new(t)),
-            GeoArrowType::Polygon(t) => Box::new(PolygonType::new(t)),
-            GeoArrowType::MultiPoint(t) => Box::new(MultiPointType::new(t)),
-            GeoArrowType::MultiLineString(t) => Box::new(MultiLineStringType::new(t)),
-            GeoArrowType::MultiPolygon(t) => Box::new(MultiPolygonType::new(t)),
-            GeoArrowType::GeometryCollection(t) => Box::new(GeometryCollectionType::new(t)),
-            GeoArrowType::Geometry(t) => Box::new(GeometryType::new(t)),
-            GeoArrowType::Rect(t) => Box::new(BoxType::new(t)),
-            GeoArrowType::Wkb(t) => Box::new(WkbType::new(t)),
-            GeoArrowType::LargeWkb(t) => Box::new(WkbType::new(t)),
-            GeoArrowType::WkbView(t) => Box::new(WkbType::new(t)),
-            GeoArrowType::Wkt(t) => Box::new(WktType::new(t)),
-            GeoArrowType::LargeWkt(t) => Box::new(WktType::new(t)),
-            GeoArrowType::WktView(t) => Box::new(WktType::new(t)),
+        match GeoArrowType::from_extension_field(&arrow_field) {
+            Ok(geoarrow_type) => match geoarrow_type {
+                GeoArrowType::Point(t) => Box::new(PointType::new(t)),
+                GeoArrowType::LineString(t) => Box::new(LineStringType::new(t)),
+                GeoArrowType::Polygon(t) => Box::new(PolygonType::new(t)),
+                GeoArrowType::MultiPoint(t) => Box::new(MultiPointType::new(t)),
+                GeoArrowType::MultiLineString(t) => Box::new(MultiLineStringType::new(t)),
+                GeoArrowType::MultiPolygon(t) => Box::new(MultiPolygonType::new(t)),
+                GeoArrowType::GeometryCollection(t) => Box::new(GeometryCollectionType::new(t)),
+                GeoArrowType::Geometry(t) => Box::new(GeometryType::new(t)),
+                GeoArrowType::Rect(t) => Box::new(BoxType::new(t)),
+                GeoArrowType::Wkb(t) => Box::new(WkbType::new(t)),
+                GeoArrowType::LargeWkb(t) => Box::new(WkbType::new(t)),
+                GeoArrowType::WkbView(t) => Box::new(WkbType::new(t)),
+                GeoArrowType::Wkt(t) => Box::new(WktType::new(t)),
+                GeoArrowType::LargeWkt(t) => Box::new(WktType::new(t)),
+                GeoArrowType::WktView(t) => Box::new(WktType::new(t)),
+            },
+            Err(e) => {
+                let err = e.to_string();
+                match name {
+                    geoarrow_schema::PointType::NAME => Box::new(PointType::invalid(&err)),
+                    geoarrow_schema::LineStringType::NAME => {
+                        Box::new(LineStringType::invalid(&err))
+                    }
+                    geoarrow_schema::PolygonType::NAME => Box::new(PolygonType::invalid(&err)),
+                    geoarrow_schema::MultiPointType::NAME => {
+                        Box::new(MultiPointType::invalid(&err))
+                    }
+                    geoarrow_schema::MultiLineStringType::NAME => {
+                        Box::new(MultiLineStringType::invalid(&err))
+                    }
+                    geoarrow_schema::MultiPolygonType::NAME => {
+                        Box::new(MultiPolygonType::invalid(&err))
+                    }
+                    geoarrow_schema::GeometryCollectionType::NAME => {
+                        Box::new(GeometryCollectionType::invalid(&err))
+                    }
+                    geoarrow_schema::GeometryType::NAME => Box::new(GeometryType::invalid(&err)),
+                    geoarrow_schema::BoxType::NAME => Box::new(BoxType::invalid(&err)),
+                    geoarrow_schema::WkbType::NAME => Box::new(WkbType::invalid(&err)),
+                    geoarrow_schema::WktType::NAME => Box::new(WktType::invalid(&err)),
+                    _ => unreachable!("Unknown GeoArrow extension type name: {name}"),
+                }
+            }
         }
     }
 }

--- a/geopolars/geopolars-extension/src/geoarrow.rs
+++ b/geopolars/geopolars-extension/src/geoarrow.rs
@@ -18,11 +18,22 @@ macro_rules! define_basic_type {
     ) => {
         $(#[$($attrss)*])*
         #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-        pub struct $struct_name(geoarrow_schema::$struct_name);
+        pub struct $struct_name(Result<geoarrow_schema::$struct_name, String>);
 
         impl $struct_name {
             pub fn new(inner: geoarrow_schema::$struct_name) -> Self {
-                Self(inner)
+                Self(Ok(inner))
+            }
+
+            pub fn invalid(error: impl std::fmt::Display) -> Self {
+                Self(Err(error.to_string()))
+            }
+
+            fn format_inner(&self) -> String {
+                match &self.0 {
+                    Ok(inner) => format!("{:?}", inner),
+                    Err(e) => format!("InvalidExtensionType({})", e),
+                }
             }
         }
 
@@ -32,7 +43,7 @@ macro_rules! define_basic_type {
             }
 
             fn serialize_metadata(&self) -> Option<Cow<'_, str>> {
-                self.0.serialize_metadata().map(Cow::Owned)
+                self.0.as_ref().ok()?.serialize_metadata().map(Cow::Owned)
             }
 
             fn dyn_clone(&self) -> Box<dyn ExtensionTypeImpl> {
@@ -52,11 +63,11 @@ macro_rules! define_basic_type {
             }
 
             fn dyn_display(&self) -> Cow<'_, str> {
-                Cow::Owned(format!("{:?}", self.0))
+                Cow::Owned(self.format_inner())
             }
 
             fn dyn_debug(&self) -> Cow<'_, str> {
-                Cow::Owned(format!("{:?}", self.0))
+                Cow::Owned(self.format_inner())
             }
         }
 
@@ -66,8 +77,10 @@ macro_rules! define_basic_type {
             }
         }
 
-        impl From<$struct_name> for geoarrow_schema::$struct_name {
-            fn from(value: $struct_name) -> Self {
+        impl TryFrom<$struct_name> for geoarrow_schema::$struct_name {
+            type Error = String;
+
+            fn try_from(value: $struct_name) -> Result<Self, Self::Error> {
                 value.0
             }
         }

--- a/geopolars/geopolars-extension/src/lib.rs
+++ b/geopolars/geopolars-extension/src/lib.rs
@@ -1,6 +1,9 @@
 pub mod factory;
 pub mod geoarrow;
 
+#[cfg(test)]
+mod tests;
+
 use std::sync::Arc;
 
 use arrow_schema::extension::ExtensionType;

--- a/geopolars/geopolars-extension/src/tests.rs
+++ b/geopolars/geopolars-extension/src/tests.rs
@@ -1,0 +1,193 @@
+use arrow_schema::extension::ExtensionType;
+use geoarrow_schema::{Dimension, PointType as GeoArrowPointType};
+use polars::prelude::DataType;
+use polars::prelude::extension::{ExtensionTypeFactory, ExtensionTypeImpl};
+
+use crate::factory::GeoArrowExtensionTypeFactory;
+use crate::geoarrow::PointType;
+
+// --- constructor helpers ---------------------------------------------------
+
+fn valid_point() -> PointType {
+    PointType::new(GeoArrowPointType::new(Dimension::XY, Default::default()))
+}
+
+fn invalid_point(msg: &str) -> PointType {
+    PointType::invalid(msg)
+}
+
+// --- TryFrom / roundtrip ---------------------------------------------------
+
+#[test]
+fn try_from_valid_roundtrips() {
+    let inner = GeoArrowPointType::new(Dimension::XY, Default::default());
+    let recovered = GeoArrowPointType::try_from(PointType::new(inner.clone())).unwrap();
+    assert_eq!(inner, recovered);
+}
+
+#[test]
+fn try_from_invalid_returns_err() {
+    assert!(GeoArrowPointType::try_from(invalid_point("bad")).is_err());
+}
+
+#[test]
+fn try_from_error_message_preserved() {
+    let err = GeoArrowPointType::try_from(invalid_point("storage mismatch")).unwrap_err();
+    assert!(err.contains("storage mismatch"), "got: {err}");
+}
+
+// --- From impl -------------------------------------------------------------
+
+#[test]
+fn from_inner_creates_valid_type() {
+    let inner = GeoArrowPointType::new(Dimension::XY, Default::default());
+    let pt = PointType::from(inner.clone());
+    assert_eq!(GeoArrowPointType::try_from(pt).unwrap(), inner);
+}
+
+// --- name() ----------------------------------------------------------------
+
+#[test]
+fn name_is_correct_for_valid_type() {
+    assert_eq!(valid_point().name(), geoarrow_schema::PointType::NAME);
+}
+
+#[test]
+fn name_is_correct_for_invalid_type() {
+    // name must always return the correct constant even when the inner value is an error
+    assert_eq!(invalid_point("oops").name(), geoarrow_schema::PointType::NAME);
+}
+
+// --- serialize_metadata ----------------------------------------------------
+
+#[test]
+fn serialize_metadata_is_none_without_crs() {
+    assert!(valid_point().serialize_metadata().is_none());
+}
+
+#[test]
+fn serialize_metadata_is_none_for_invalid() {
+    assert!(invalid_point("err").serialize_metadata().is_none());
+}
+
+// --- dyn_display / dyn_debug -----------------------------------------------
+
+#[test]
+fn dyn_display_valid_does_not_contain_invalid_marker() {
+    let pt = valid_point();
+    let s = pt.dyn_display();
+    assert!(!s.contains("InvalidExtensionType"), "got: {s}");
+}
+
+#[test]
+fn dyn_display_invalid_contains_error_message() {
+    let pt = invalid_point("bad storage");
+    let s = pt.dyn_display();
+    assert!(s.contains("bad storage"), "got: {s}");
+}
+
+#[test]
+fn dyn_debug_valid_does_not_contain_invalid_marker() {
+    let pt = valid_point();
+    let s = pt.dyn_debug();
+    assert!(!s.contains("InvalidExtensionType"), "got: {s}");
+}
+
+#[test]
+fn dyn_debug_invalid_contains_error_message() {
+    let pt = invalid_point("bad storage");
+    let s = pt.dyn_debug();
+    assert!(s.contains("bad storage"), "got: {s}");
+}
+
+// --- Clone -----------------------------------------------------------------
+
+#[test]
+fn clone_valid_type_is_equal() {
+    let pt = valid_point();
+    assert_eq!(pt.clone(), pt);
+}
+
+#[test]
+fn clone_invalid_type_is_still_invalid() {
+    let pt = invalid_point("err");
+    assert!(GeoArrowPointType::try_from(pt.clone()).is_err());
+}
+
+// --- PartialEq -------------------------------------------------------------
+
+#[test]
+fn equal_valid_types() {
+    assert_eq!(valid_point(), valid_point());
+}
+
+#[test]
+fn equal_invalid_types_same_message() {
+    assert_eq!(invalid_point("e"), invalid_point("e"));
+}
+
+#[test]
+fn unequal_invalid_types_different_messages() {
+    assert_ne!(invalid_point("e1"), invalid_point("e2"));
+}
+
+#[test]
+fn unequal_valid_and_invalid() {
+    assert_ne!(valid_point(), invalid_point("err"));
+}
+
+// --- factory: happy path ---------------------------------------------------
+
+#[test]
+fn factory_valid_storage_produces_valid_type() {
+    let factory = GeoArrowExtensionTypeFactory;
+    // WKB storage is plain Binary, which needs no extra feature flags.
+    let ext = factory.create_type_instance(
+        geoarrow_schema::WkbType::NAME,
+        &DataType::Binary,
+        None,
+    );
+    let display = ext.dyn_display();
+    assert!(
+        !display.contains("InvalidExtensionType"),
+        "expected valid type, got: {display}"
+    );
+}
+
+// --- factory: error path ---------------------------------------------------
+
+#[test]
+fn factory_invalid_storage_does_not_panic() {
+    let factory = GeoArrowExtensionTypeFactory;
+    let _ext = factory.create_type_instance(
+        geoarrow_schema::PointType::NAME,
+        &DataType::Int32,
+        None,
+    );
+}
+
+#[test]
+fn factory_invalid_storage_produces_invalid_state() {
+    let factory = GeoArrowExtensionTypeFactory;
+    let ext = factory.create_type_instance(
+        geoarrow_schema::PointType::NAME,
+        &DataType::Int32,
+        None,
+    );
+    let display = ext.dyn_display();
+    assert!(
+        display.contains("InvalidExtensionType"),
+        "expected invalid state, got: {display}"
+    );
+}
+
+#[test]
+fn factory_invalid_storage_name_still_correct() {
+    let factory = GeoArrowExtensionTypeFactory;
+    let ext = factory.create_type_instance(
+        geoarrow_schema::PointType::NAME,
+        &DataType::Int32,
+        None,
+    );
+    assert_eq!(ext.name(), geoarrow_schema::PointType::NAME);
+}

--- a/geopolars/geopolars-extension/src/tests.rs
+++ b/geopolars/geopolars-extension/src/tests.rs
@@ -55,7 +55,10 @@ fn name_is_correct_for_valid_type() {
 #[test]
 fn name_is_correct_for_invalid_type() {
     // name must always return the correct constant even when the inner value is an error
-    assert_eq!(invalid_point("oops").name(), geoarrow_schema::PointType::NAME);
+    assert_eq!(
+        invalid_point("oops").name(),
+        geoarrow_schema::PointType::NAME
+    );
 }
 
 // --- serialize_metadata ----------------------------------------------------
@@ -142,11 +145,7 @@ fn unequal_valid_and_invalid() {
 fn factory_valid_storage_produces_valid_type() {
     let factory = GeoArrowExtensionTypeFactory;
     // WKB storage is plain Binary, which needs no extra feature flags.
-    let ext = factory.create_type_instance(
-        geoarrow_schema::WkbType::NAME,
-        &DataType::Binary,
-        None,
-    );
+    let ext = factory.create_type_instance(geoarrow_schema::WkbType::NAME, &DataType::Binary, None);
     let display = ext.dyn_display();
     assert!(
         !display.contains("InvalidExtensionType"),
@@ -159,21 +158,15 @@ fn factory_valid_storage_produces_valid_type() {
 #[test]
 fn factory_invalid_storage_does_not_panic() {
     let factory = GeoArrowExtensionTypeFactory;
-    let _ext = factory.create_type_instance(
-        geoarrow_schema::PointType::NAME,
-        &DataType::Int32,
-        None,
-    );
+    let _ext =
+        factory.create_type_instance(geoarrow_schema::PointType::NAME, &DataType::Int32, None);
 }
 
 #[test]
 fn factory_invalid_storage_produces_invalid_state() {
     let factory = GeoArrowExtensionTypeFactory;
-    let ext = factory.create_type_instance(
-        geoarrow_schema::PointType::NAME,
-        &DataType::Int32,
-        None,
-    );
+    let ext =
+        factory.create_type_instance(geoarrow_schema::PointType::NAME, &DataType::Int32, None);
     let display = ext.dyn_display();
     assert!(
         display.contains("InvalidExtensionType"),
@@ -184,10 +177,7 @@ fn factory_invalid_storage_produces_invalid_state() {
 #[test]
 fn factory_invalid_storage_name_still_correct() {
     let factory = GeoArrowExtensionTypeFactory;
-    let ext = factory.create_type_instance(
-        geoarrow_schema::PointType::NAME,
-        &DataType::Int32,
-        None,
-    );
+    let ext =
+        factory.create_type_instance(geoarrow_schema::PointType::NAME, &DataType::Int32, None);
     assert_eq!(ext.name(), geoarrow_schema::PointType::NAME);
 }


### PR DESCRIPTION
Closes #260.

## What this changes

`GeoArrowExtensionTypeFactory::create_type_instance` is infallible by the Polars API contract, so when `GeoArrowType::from_extension_field` fails (incompatible storage type for the named extension), the factory was panicking via `.expect(...)`.

This PR stores the error inside the wrapper type instead of panicking:

- **`geoarrow.rs`** — changes the macro-generated structs from `struct PointType(T)` to `struct PointType(Result<T, String>)`. Adds an `invalid(error)` constructor and a private `format_inner` helper (shared by `dyn_display` and `dyn_debug` to avoid duplication). `serialize_metadata` returns `None` on error. `name()` always returns the correct constant regardless of validity. Replaces the infallible `From<WrapperType> for geoarrow_schema::T` with `TryFrom`.

- **`factory.rs`** — replaces `.expect(...)` with a `match`; the error arm dispatches by `name` to create the right wrapper type in invalid state.

## Tests (22 new)

Covers the valid and error paths for:
- `TryFrom` roundtrip and error message preservation
- `From` infallible constructor
- `name()` with valid and invalid inner value
- `serialize_metadata` returning `None` in both cases
- `dyn_display` / `dyn_debug` output for valid and invalid types
- `Clone` on invalid types
- `PartialEq` — same-error equal, different-error unequal, valid ≠ invalid
- Factory happy path (valid storage → valid state)
- Factory error path (incompatible storage → invalid state, no panic, correct name)