### PR TITLE
chore: add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,66 @@
+name: Bug report
+description: Something isn't working correctly
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill in as much detail as you can.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of what the bug is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: A minimal code snippet that reproduces the issue.
+      render: rust
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened? Include any error messages or panics.
+    validations:
+      required: true
+
+  - type: input
+    id: geopolars-version
+    attributes:
+      label: GeoPolars version
+      placeholder: e.g. 0.1.0-alpha.4 or git rev
+    validations:
+      required: true
+
+  - type: input
+    id: rust-version
+    attributes:
+      label: Rust version
+      description: Output of `rustc --version`
+      placeholder: e.g. rustc 1.85.0
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: e.g. macOS 14, Ubuntu 22.04, Windows 11
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discussions
+    url: https://github.com/pola-rs/geopolars/discussions
+    about: For questions, ideas, and general discussion about GeoPolars

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,39 @@
+name: Feature request
+description: Suggest a new spatial operation or capability
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! GeoPolars is early-stage, so community input on what operations matter most is very helpful.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What feature or spatial operation would you like to see?
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: What problem would this solve? What are you trying to accomplish?
+    validations:
+      required: true
+
+  - type: textarea
+    id: geopandas-equivalent
+    attributes:
+      label: GeoPandas / Shapely equivalent
+      description: |
+        If there is a GeoPandas or Shapely equivalent, link it or show example usage.
+        GeoPolars aims to provide a similar API surface.
+      render: python
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Any other context, links, or references (e.g. GeoRust crate that could implement this).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Summary
+
+<!-- What does this PR do? Link to the relevant issue if one exists. -->
+
+Closes #
+
+## Changes
+
+<!-- Brief description of what changed and why. -->
+
+## Test plan
+
+<!-- How was this tested? New tests added? Existing tests cover it? -->
+
+- [ ] `cargo test` passes
+- [ ] `cargo clippy` passes


### PR DESCRIPTION
Closes #128.

Adds four files under `.github/`:

**Issue templates** (`.github/ISSUE_TEMPLATE/`):
- `bug_report.yml` — structured form capturing description, minimal reproduction, expected vs actual behavior, GeoPolars version, Rust version, and OS
- `feature_request.yml` — captures use case and optional GeoPandas/Shapely equivalent to guide API design decisions
- `config.yml` — template chooser config with a link to Discussions for questions

**PR template** (`.github/PULL_REQUEST_TEMPLATE.md`):
- Summary with auto-closing issue link
- Changes section
- Test checklist (`cargo test`, `cargo clippy`)